### PR TITLE
Minute documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Coming soon...
 ### Containerized Mellanox OFED - Run
 ```
 # docker run --rm -it \
--v /run/mellanox/drivers:/run/mellanox/drivers \
+-v /run/mellanox/drivers:/run/mellanox/drivers:shared \
 -v /etc/network:/etc/network \
 --net=host --privileged ofed-driver
 ```


### PR DESCRIPTION
When running OFED driver container modify run example
line to create /var/mellanox/drivers with mode shared
to allow reflection of mounts from container onto the host