### PR TITLE
Update deployment example

### DIFF
--- a/deployment/ofed-driver-pod.yaml
+++ b/deployment/ofed-driver-pod.yaml
@@ -16,7 +16,12 @@ spec:
         - name: run-mofed
           mountPath: /run/mellanox/drivers
           mountPropagation: Bidirectional
+        - name: etc-network
+          mountPath: /etc/network
   volumes:
     - name: run-mofed
       hostPath:
         path: /run/mellanox/drivers
+    - name: etc-network
+      hostPath:
+        path: /etc/network


### PR DESCRIPTION
Update deployment example to include mount to
the host's `/etc/network` to allow driver restart
script to re-trigger network configuration.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>