### PR TITLE
run apt-get update before installing linux headers

### DIFF
--- a/gpu-direct/ubuntu/entrypoint.sh
+++ b/gpu-direct/ubuntu/entrypoint.sh
@@ -29,6 +29,7 @@ function has_files_matching() {
 
 function install_prereq_runtime() {
     # Install linux headers
+    apt-get -yq update
     apt-get -yq install linux-headers-${KERNEL_VERSION}
     return $?
 }


### PR DESCRIPTION
required for kernel headers installation when
driver container runs against newer kernels.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>