### PR TITLE
Update RHEL entrypoint script

### DIFF
--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -1,41 +1,24 @@
-# TODO:
-#  1. Test and Fix issues in Dockerfile
+FROM registry.access.redhat.com/ubi8:latest
 
-## Stage: Build driver
-FROM centos:centos8 AS build
-
-# Build Args - pass with --build-arg flag during build
-ARG D_OFED_VERSION="5.0-2.1.8.0"
-ARG D_OS="rhel8.2"
+ARG D_OFED_VERSION="5.2-1.0.4.0"
+ARG D_OS_VERSION="8.2"
+ARG D_OS="rhel${D_OS_VERSION}"
+ENV D_OS=${D_OS}
 ARG D_ARCH="x86_64"
 ARG D_OFED_PATH="MLNX_OFED_LINUX-${D_OFED_VERSION}-${D_OS}-${D_ARCH}"
+ENV D_OFED_PATH=${D_OFED_PATH}
 
 ARG D_OFED_TARBALL_NAME="MLNX_OFED_LINUX-${D_OFED_VERSION}-${D_OS}-${D_ARCH}.tgz"
 ARG D_OFED_URL_PATH="https://www.mellanox.com/downloads/ofed/MLNX_OFED-${D_OFED_VERSION}/${D_OFED_TARBALL_NAME}"
 
-# Internal arguments
 ARG D_WITHOUT_FLAGS="--without-rshim-dkms --without-iser-dkms --without-isert-dkms --without-srp-dkms --without-kernel-mft-dkms --without-mlnx-rdma-rxe-dkms"
+ENV D_WITHOUT_FLAGS=${D_WITHOUT_FLAGS}
 
 # Download and extract tarball
 WORKDIR /root
 ADD ${D_OFED_URL_PATH} ./
 RUN tar -xf ${D_OFED_TARBALL_NAME}
-RUN dnf -y install make gcc wget perl createrepo kernel-core-$(uname -r) kernel-devel-$(uname -r) pciutils python36-devel ethtool lsof elfutils-libelf-devel rpm-build kernel-rpm-macros python36 tk numactl-libs libmnl tcl binutils kmod procps git autoconf automake libtool
-
-# Install OFED
-RUN /bin/bash -c '/root/MLNX_OFED_LINUX-${D_OFED_VERSION}-${D_OS}-${D_ARCH}/mlnxofedinstall --without-fw-update --kernel-only --add-kernel-support --distro ${D_OS} --skip-repo --force ${D_WITHOUT_FLAGS}'
-
-# Post Install steps
-
-# dont load kernel (builtin) esp4/6 modules related to innova
-RUN sed -i '/ESP_OFFLOAD_LOAD=yes/c\ESP_OFFLOAD_LOAD=no' /etc/infiniband/openib.conf
-
-# Put a post start hook in place for restoring network configurations of mellanox net devs
-RUN cp /root/MLNX_OFED_LINUX-${D_OFED_VERSION}-${D_OS}-${D_ARCH}/docs/scripts/openibd-post-start-configure-interfaces/post-start-hook.sh /etc/infiniband/post-start-hook.sh && \
-    chmod +x /etc/infiniband/post-start-hook.sh
-
-## Stage: Build container
-FROM build
+RUN dnf -y install autoconf automake binutils ethtool gcc git hostname kmod libmnl libtool lsof make pciutils perl procps python36 python36-devel rpm-build tcl tk wget
 
 WORKDIR /
 ADD ./entrypoint.sh /root/entrypoint.sh

--- a/rhel/entrypoint.sh
+++ b/rhel/entrypoint.sh
@@ -1,6 +1,23 @@
 #!/bin/bash -x
+
+set_driver_readiness() {
+    touch /.driver-ready
+}
+
+unset_driver_readiness() {
+    rm -f /.driver-ready
+}
+
+exit_on_error() {
+    $@
+    if [[ $? -ne 0 ]]; then
+        echo "Error occured while executing: $1"
+        exit 1
+    fi
+}
+
 mount_rootfs() {
-    echo "Mounting OFED driver container rootfs..."
+    echo "Mounting Mellanox OFED driver container rootfs..."
     mount --make-runbindable /sys
     mount --make-private /sys
     mkdir -p /run/mellanox/drivers
@@ -14,9 +31,114 @@ unmount_rootfs() {
     fi
 }
 
-/etc/init.d/openibd restart
-ofed_info -s
+handle_signal() {
+    unset_driver_readiness
+    unmount_rootfs
+    echo "Stopping Mellanox OFED Driver..."
+    /etc/init.d/openibd force-stop
+    exit 0
+}
+
+ofed_exist_for_kernel() {
+    # check if mlx5_core exists in dkms under running kernel, this should be sufficient to hint us if
+    # OFED drivers are installed for the running kernel
+    if [[ -e /usr/lib/modules/${KERNEL_VERSION}/extra/mlnx-ofa_kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko ]]; then
+        echo "OFED driver found for kernel"
+        return 0
+    fi
+    echo "No OFED driver found for kernel ${KERNEL_VERSION}"
+    return 1
+
+}
+
+rebuild_driver() {
+    # Rebuild driver in case installed driver kernel version differs from running kernel
+    echo "Rebuilding driver"
+    #dnf -y clean expire-cache
+    #dkms autoinstall
+}
+
+start_driver() {
+    modprobe -r rpcrdma ib_srpt ib_isert rdma_cm
+    modprobe -r i40iw ib_core
+    /etc/init.d/openibd restart
+    if [[ $? -ne 0 ]]; then
+        echo "Error occured while restarting driver"
+        return 1
+    fi
+    ofed_info -s
+}
+
+# Install the kernel modules header/builtin/order files and generate the kernel version string.
+_install_prerequisites() {
+    echo "Enabling RHOCP and EUS RPM repos..."
+    OPENSHIFT_VERSION=4.6
+    RHEL_VERSION=8.2
+
+    dnf config-manager --set-enabled rhocp-${OPENSHIFT_VERSION}-for-rhel-8-x86_64-rpms || true
+    if ! dnf makecache --releasever=${RHEL_VERSION}; then
+    	dnf config-manager --set-disabled rhocp-${OPENSHIFT_VERSION}-for-rhel-8-x86_64-rpms
+    fi
+
+    dnf config-manager --set-enabled rhel-8-for-x86_64-baseos-eus-rpms  || true
+    if ! dnf makecache --releasever=${RHEL_VERSION}; then
+    	dnf config-manager --set-disabled rhel-8-for-x86_64-baseos-eus-rpms
+    fi
+
+    echo "Installing dependencies"
+    dnf -q -y --releasever=${RHEL_VERSION} install createrepo elfutils-libelf-devel kernel-rpm-macros numactl-libs
+
+    echo "Installing Linux kernel headers..."
+    dnf -q -y --releasever=${RHEL_VERSION} install kernel-headers-${KERNEL_VERSION} kernel-devel-${KERNEL_VERSION}
+
+    echo "Installing Linux kernel module files..."
+    dnf -q -y --releasever=${RHEL_VERSION} install kernel-core-${KERNEL_VERSION}
+
+    # Prevent depmod from giving a WARNING about missing files 
+    touch /lib/modules/${KERNEL_VERSION}/modules.order
+    touch /lib/modules/${KERNEL_VERSION}/modules.builtin
+
+    depmod ${KERNEL_VERSION}
+
+    echo "Generating Linux kernel version string..."
+    sh /usr/src/kernels/${KERNEL_VERSION}/scripts/extract-vmlinux /lib/modules/${KERNEL_VERSION}/vmlinuz | strings | grep -E '^Linux version' | sed 's/^\(.*\)\s\+(.*)$/\1/' > version
+    if [ -z "$(<version)" ]; then
+        echo "Could not locate Linux kernel version string" >&2
+        return 1
+    fi
+    mv version /lib/modules/${KERNEL_VERSION}/proc
+}
+
+_install_ofed() {
+    # Install OFED
+    /bin/bash -c '/root/${D_OFED_PATH}/mlnxofedinstall --without-fw-update --kernel-only --add-kernel-support --distro ${D_OS} --skip-repo --force ${D_WITHOUT_FLAGS}'
+    
+    # Post Install steps
+    
+    # dont load kernel (builtin) esp4/6 modules related to innova
+    sed -i '/ESP_OFFLOAD_LOAD=yes/c\ESP_OFFLOAD_LOAD=no' /etc/infiniband/openib.conf
+    
+    # Put a post start hook in place for restoring network configurations of mellanox net devs
+    cp /root/${D_OFED_PATH}/docs/scripts/openibd-post-start-configure-interfaces/post-start-hook.sh /etc/infiniband/post-start-hook.sh
+    chmod +x /etc/infiniband/post-start-hook.sh
+}
+
+KERNEL_VERSION=$(uname -r)
+
+
+# Unset driver readiness in case it was set in a previous run of this container
+# and container was killed
+unset_driver_readiness
+ofed_exist_for_kernel
+if [[ $? -ne 0 ]]; then
+    _install_prerequisites
+    _install_ofed
+    rebuild_driver
+fi
+
+exit_on_error start_driver
 mount_rootfs
+set_driver_readiness
 trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
-trap "unmount_rootfs" EXIT
-sleep infinity
+trap "handle_signal" EXIT
+sleep infinity & wait

--- a/ubuntu/entrypoint.sh
+++ b/ubuntu/entrypoint.sh
@@ -21,7 +21,7 @@ function exit_on_error() {
 }
 
 function mount_rootfs() {
-    echo "Mounting OFED driver container rootfs..."
+    echo "Mounting Mellanox OFED driver container rootfs..."
     mount --make-runbindable /sys
     mount --make-private /sys
     mkdir -p /run/mellanox/drivers
@@ -29,6 +29,7 @@ function mount_rootfs() {
 }
 
 function unmount_rootfs() {
+    echo "Unmounting Mellanox OFED driver rootfs..."
     if findmnt -r -o TARGET | grep "/run/mellanox/drivers" > /dev/null; then
       umount -l -R /run/mellanox/drivers
     fi
@@ -36,7 +37,6 @@ function unmount_rootfs() {
 
 function handle_signal() {
     unset_driver_readiness
-    echo "Unmounting Mellanox OFED driver rootfs..."
     unmount_rootfs
     echo "Stopping Mellanox OFED Driver..."
     /etc/init.d/openibd force-stop


### PR DESCRIPTION
The RHEL ofed-driver did not have a working entrypoint script.
Will validate if we need the extra `modprobe -r`.

Also it's a bit strange that the bash functions are in the form:`function does_something() {` as it combines both of the fn declaration styles. (Style 1: `does_something() {`, Style 2: `function does_something {`)

I kept the same style as was in the ubuntu script, but just wanted to note this irregularity.