### PR TITLE
Add support for nvidia-peermem module builtin in GPU driver

### DIFF
--- a/gpu-direct/ubuntu/entrypoint.sh
+++ b/gpu-direct/ubuntu/entrypoint.sh
@@ -1,4 +1,9 @@
 #!/bin/bash -x
+
+# allow builtin nvidia_peermem module from GPU driver,
+# if false, forces to use nv_peer_mem module from the image
+ALLOW_MOD_FROM_GPU_DRIVER="${ALLOW_MOD_FROM_GPU_DRIVER:-false}"
+
 MOFED=/run/mellanox/drivers
 NVIDIA=/run/nvidia/drivers
 KERNEL_VERSION=$(uname -r)
@@ -81,13 +86,31 @@ function inject_nvidia_driver() {
     # ln -sf ${NVIDIA}/var/lib/dkms/nvidia /var/lib/dkms/nvidia
 }
 
+function use_peermem_from_gpu_driver() {
+    if ! $ALLOW_MOD_FROM_GPU_DRIVER; then
+        return 1
+    fi
+    # check if GPU driver include nvidia-peermem module
+    has_files_matching /lib/modules/${KERNEL_VERSION}/updates/dkms/ nvidia-peermem.ko
+    return $?
+}
+
+function load_nvidia_peermem() {
+    depmod -a "$KERNEL_VERSION" && \
+    modprobe nvidia-peermem
+    return $?
+}
+
+function unload_nvidia_peermem() {
+    modprobe -r nvidia-peermem
+    return $?
+}
+
 function prepare_build_env() {
     # Patch filesystem with components from both Mellanox and Nvidia Drivers
     touch /lib/modules/${KERNEL_VERSION}/modules.order && \
     touch /lib/modules/${KERNEL_VERSION}/modules.builtin && \
     mkdir -p /lib/modules/${KERNEL_VERSION}/updates/dkms && \
-    mkdir -p /etc/infiniband && \
-    cp /root/nv_peer_memory/nv_peer_mem.conf /etc/infiniband/ && \
     inject_mofed_driver && \
     inject_nvidia_driver
     return $?
@@ -95,6 +118,8 @@ function prepare_build_env() {
 
 function build_modules() {
     # Build NV PEER MEMORY module
+    mkdir -p /etc/infiniband && \
+    cp /root/nv_peer_memory/nv_peer_mem.conf /etc/infiniband/ && \
     cd /root/nv_peer_memory && \
     make clean && \
     make && \
@@ -107,6 +132,10 @@ function build_modules() {
 function handle_signal() {
     echo 'Stopping nv_peer_memory driver'
     unset_driver_readiness
+    if use_peermem_from_gpu_driver; then
+        unload_nvidia_peermem
+        return
+    fi
     /root/nv_peer_memory/nv_peer_mem stop
 }
 
@@ -115,7 +144,11 @@ function handle_signal() {
 unset_driver_readiness
 exit_on_error install_prereq_runtime
 exit_on_error prepare_build_env
-exit_on_error build_modules
+if use_peermem_from_gpu_driver; then
+    exit_on_error load_nvidia_peermem
+else
+    exit_on_error build_modules
+fi
 set_driver_readiness
 trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
 trap "handle_signal" EXIT


### PR DESCRIPTION
GPU-direct container now supports loading of the nvidia-peermem
module which is a part of GPU driver (465 branch)
By default, nv_peer_mem module from the image will be used.
If "ALLOW_MOD_FROM_GPU_DRIVER" environment variable is "true",
entrypoin.sh will check for nvidia_peermem module presence and will use
it if it exists. If module is not found, nv_peer_mem will be used
as a fallback.


Related PR in Mellanox/network-operator repo https://github.com/Mellanox/network-operator/pull/190