### PR TITLE
Update udev rules for OFED 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Coming soon...
 # docker run --rm -it \
 -v /run/mellanox/drivers:/run/mellanox/drivers:shared \
 -v /etc/network:/etc/network \
+-v /host/etc:/etc \
+-v /host/lib/udev:/lib/udev \
 --net=host --privileged ofed-driver
 ```
 

--- a/deployment/ofed-driver-pod.yaml
+++ b/deployment/ofed-driver-pod.yaml
@@ -18,6 +18,10 @@ spec:
           mountPropagation: Bidirectional
         - name: etc-network
           mountPath: /etc/network
+        - name: host-etc
+          mountPath: /host/etc
+        - name: host-udev
+          mountPath: /host/lib/udev
   volumes:
     - name: run-mofed
       hostPath:
@@ -25,3 +29,9 @@ spec:
     - name: etc-network
       hostPath:
         path: /etc/network
+    - name: host-etc
+      hostPath:
+        path: /etc
+    - name: host-udev
+      hostPath:
+        path: /lib/udev


### PR DESCRIPTION
We need to update udev rules to not allow MOFED driver update NIC
names.

New udev rules should be cleaned up during pod termination.

Signed-off-by: Ivan Kolodyazhny <ikolodiazhny@nvidia.com>