### PR TITLE
Support host without ifup in OFED container

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -26,7 +26,7 @@ RUN set -x && \
     sed -i '/ESP_OFFLOAD_LOAD=yes/c\ESP_OFFLOAD_LOAD=no' /etc/infiniband/openib.conf && \
     cp /root/${D_OFED_PATH}/docs/scripts/openibd-post-start-configure-interfaces/post-start-hook.sh /etc/infiniband/post-start-hook.sh && \
     chmod +x /etc/infiniband/post-start-hook.sh && \
-    apt-get -yq install iproute2 net-tools ifupdown linux-modules-$(uname -r) && \
+    apt-get -yq install iproute2 net-tools ifupdown linux-modules-$(uname -r) netplan.io && \
     rm -rf /root/${D_OFED_PATH} && \
     apt-get clean autoclean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
As part of openibd restart, mlnx_interface_mgr.sh is running and
trying to read /etc/network/interfaces file in case ifup exists
and netplan doesn't.
In case the host doesn't include ifup but the container do we
will fail on reading this file and restarting openibd.
The container need to work on both cases where the host includes
ifup and when it doesn't.
In order to support it we will install both ifup and netplan in the
container and on run time we will try to read /etc/network/interfaces
(which is mounted from host) and if not exist assume that ifup is
missing in the host, in such case we will rename the ifup file in
the container so that mlnx_interface_mgr.sh will not find it and
won't be trying to read missing /etc/network/interfaces file.

Signed-off-by: Mykhaylo Yehorov <mykhayloy@nvidia.com>