### PR TITLE
Dockerfile and entrypoint script updates

### DIFF
--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8:latest
+ARG D_BASE_IMAGE=registry.access.redhat.com/ubi8:latest
+FROM $D_BASE_IMAGE
 
 ARG D_OFED_VERSION="5.3-1.0.0.1"
 ARG D_OS_VERSION="8.2"

--- a/rhel/entrypoint.sh
+++ b/rhel/entrypoint.sh
@@ -63,6 +63,15 @@ rebuild_driver() {
     #dkms autoinstall
 }
 
+function fix_src_link() {
+    local ARCH=$(uname -m)
+    local KVER=$(uname -r)
+    local target=$(readlink /usr/src/ofa_kernel/default)
+    if [[ -e /usr/src/ofa_kernel/${ARCH}/${KVER} ]] && [[ -L /usr/src/ofa_kernel/default ]] && [[ "${target:0:1}" = / ]]; then
+        ln -snf "${ARCH}/${KVER}" /usr/src/ofa_kernel/default
+    fi
+}
+
 start_driver() {
     modprobe -r rpcrdma ib_srpt ib_isert rdma_cm
     modprobe -r i40iw ib_core
@@ -242,6 +251,7 @@ if [[ $? -ne 0 ]]; then
     _install_ofed
     rebuild_driver
 fi
+fix_src_link
 
 unload_modules rpcrdma rdma_cm
 create_udev_rules

--- a/ubuntu/entrypoint.sh
+++ b/ubuntu/entrypoint.sh
@@ -66,6 +66,15 @@ function rebuild_driver() {
     dkms autoinstall
 }
 
+function fix_src_link() {
+    local ARCH=$(uname -m)
+    local KVER=$(uname -r)
+    local target=$(readlink /usr/src/ofa_kernel/default)
+    if [[ -e /usr/src/ofa_kernel/${ARCH}/${KVER} ]] && [[ -L /usr/src/ofa_kernel/default ]] && [[ "${target:0:1}" = / ]]; then
+        ln -snf "${ARCH}/${KVER}" /usr/src/ofa_kernel/default
+    fi
+}
+
 function sync_network_configuration_tools() {
     # As part of openibd restart, mlnx_interface_mgr.sh is running and trying to read
     # /etc/network/interfaces file in case ifup exists and netplan doesn't.
@@ -199,6 +208,7 @@ ofed_exist_for_kernel
 if [[ $? -ne 0 ]]; then
     rebuild_driver
 fi
+fix_src_link
 
 unload_modules rpcrdma rdma_cm
 create_udev_rules


### PR DESCRIPTION
- Add ability to override base image for RHEL
- Replace target of symbolic link /usr/src/ofa_kernel/default with relative path
  to make it available from host or another container

Signed-off-by: Mykhaylo Yehorov <mykhayloy@nvidia.com>